### PR TITLE
Added option for custom sidebar path file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-auto-sidebars",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Auto sidebars plugin for Docusaurus",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,55 @@
+import fs from "fs";
+import path from "path";
+import { LoadContext, Plugin } from "@docusaurus/types";
+import { PluginOptions } from "./types";
 
-import fs from 'fs';
-import path from 'path';
-import {LoadContext, Plugin} from '@docusaurus/types';
-import {PluginOptions} from './types';
+import { generate } from "./generator";
 
-import {generate} from './generator';
-
-const _moduleFileTemplate=`
+const _moduleFileTemplate = `
 module.exports = {
-    docs: $items$
+  docs: $items$
 };
 `;
 
-function generateSidebarFile(siteDir:string, docsRelPath: string )
-{
+function generateSidebarFile(
+  siteDir: string,
+  docsRelPath: string,
+  customSidebarPath: string
+) {
   const docsPath = path.join(siteDir, docsRelPath);
 
   var sidebarItems = generate(docsPath);
-  var data = _moduleFileTemplate.replace("$items$", JSON.stringify(sidebarItems, null, '    '));
-  
-  const sidebarPath = path.join(siteDir, '/sidebars.auto.js');
-  fs.writeFileSync(sidebarPath, data, 'utf8');
+  var data = _moduleFileTemplate.replace(
+    "$items$",
+    JSON.stringify(sidebarItems, null, "    ")
+  );
 
+  const sidebarPath = path.join(siteDir, customSidebarPath);
+  fs.writeFileSync(sidebarPath, data, "utf8");
 }
 
 const DEFAULT_OPTIONS: PluginOptions = {
-  path: 'docs', // Path to docs on filesystem, relative to site dir.
+  path: "docs", // Path to docs on filesystem, relative to site dir.
+  sidebarPath: "sidebars.auto.js", // Path to generated sidebar path.
 };
 
 export default function pluginContentPages(
   context: LoadContext,
-  opts: Partial<PluginOptions>,
+  opts: Partial<PluginOptions>
 ): Plugin<null> {
-  const options = {...DEFAULT_OPTIONS, ...opts};
+  const options = { ...DEFAULT_OPTIONS, ...opts };
 
-  generateSidebarFile(context.siteDir, options.path);
+  generateSidebarFile(context.siteDir, options.path, options.sidebarPath);
 
   return {
-    name: 'docusaurus-plugin-auto-sidebars',
+    name: "docusaurus-plugin-auto-sidebars",
     getPathsToWatch() {
-      const contentPath = path.join(context.siteDir, options.path, 'sidebars.yaml');
-      
+      const contentPath = path.join(
+        context.siteDir,
+        options.path,
+        "sidebars.yaml"
+      );
+
       return [`${contentPath}`];
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
 export interface PluginOptions {
-    path:string
+  path: string;
+  sidebarPath: string;
 }
-


### PR DESCRIPTION
I think it would be useful if we could specify a custom sidebar.auto.js file instead of using the default one (i.e. `sidebars.auto.js`)

**Potential use case:** Website with multiple docs sections. 
